### PR TITLE
Don't specific clang version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ lint:
 clean:
 	rm $(BINDIR)/*
 
-CLANG ?= clang-14
+CLANG ?= clang
 CFLAGS := -O2 -g -Wall -Werror $(CFLAGS)
 
 ebpf: export BPF_CLANG := $(CLANG)


### PR DESCRIPTION
Try make ebpf
**********************************************************************
cd component/ebpf/ && go generate ./...
Error: exec: "llvm-strip-14": executable file not found in $PATH
exit status 1
redir/auto_redirect.go:24: running "go": exit status 1
Error: exec: "llvm-strip-14": executable file not found in $PATH
exit status 1
tc/redirect_to_tun.go:21: running "go": exit status 1
make: *** [Makefile:157：ebpf] 错误 1
***********************************************************************
We have llvm-strip but no llvm-strip-14 here