### PR TITLE
using REJECT when doesn't match any rule （修复流量泄漏）

### DIFF
--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -294,7 +294,7 @@ func handleUDPConn(packet *inbound.PacketAdapter) {
 		case mode == Direct:
 			log.Infoln("[UDP] %s --> %s using DIRECT", metadata.SourceDetail(), metadata.RemoteAddress())
 		default:
-			log.Infoln("[UDP] %s --> %s doesn't match any rule using DIRECT", metadata.SourceDetail(), metadata.RemoteAddress())
+			log.Infoln("[UDP] %s --> %s doesn't match any rule using REJECT", metadata.SourceDetail(), metadata.RemoteAddress())
 		}
 
 		oAddr := metadata.DstIP
@@ -360,7 +360,7 @@ func handleTCPConn(connCtx C.ConnContext) {
 	case mode == Direct:
 		log.Infoln("[TCP] %s --> %s using DIRECT", metadata.SourceDetail(), metadata.RemoteAddress())
 	default:
-		log.Infoln("[TCP] %s --> %s doesn't match any rule using DIRECT", metadata.SourceAddress(), metadata.RemoteAddress())
+		log.Infoln("[TCP] %s --> %s doesn't match any rule using REJECT", metadata.SourceAddress(), metadata.RemoteAddress())
 	}
 
 	handleSocket(connCtx, remoteConn)
@@ -430,5 +430,5 @@ func match(metadata *C.Metadata) (C.Proxy, C.Rule, error) {
 		}
 	}
 
-	return proxies["DIRECT"], nil, nil
+	return proxies["REJECT"], nil, nil
 }


### PR DESCRIPTION
没有匹配到任何规则的连接应该直接REJECT,防止未预期的流量泄漏。
如
```
rules:
// other rules
- Match,proxy
```
可能由于节点不支持udp等原因导致Match规则没有匹配到，导致流量走直连，不符合用户预期和Match的语义。