### PR TITLE
proxy-provider and proxy-groups support exclude node by node type

### DIFF
--- a/adapter/outboundgroup/fallback.go
+++ b/adapter/outboundgroup/fallback.go
@@ -132,6 +132,7 @@ func NewFallback(option *GroupCommonOption, providers []provider.ProxyProvider) 
 			},
 			option.Filter,
 			option.ExcludeFilter,
+            option.ExcludeType,
 			providers,
 		}),
 		disableUDP: option.DisableUDP,

--- a/adapter/outboundgroup/loadbalance.go
+++ b/adapter/outboundgroup/loadbalance.go
@@ -229,6 +229,7 @@ func NewLoadBalance(option *GroupCommonOption, providers []provider.ProxyProvide
 			},
 			option.Filter,
 			option.ExcludeFilter,
+            option.ExcludeType,
 			providers,
 		}),
 		strategyFn: strategyFn,

--- a/adapter/outboundgroup/parser.go
+++ b/adapter/outboundgroup/parser.go
@@ -31,6 +31,7 @@ type GroupCommonOption struct {
 	DisableUDP    bool     `group:"disable-udp,omitempty"`
 	Filter        string   `group:"filter,omitempty"`
 	ExcludeFilter string   `group:"exclude-filter,omitempty"`
+    ExcludeType   string   `group:"exclude-type,omitempty"`
 }
 
 func ParseProxyGroup(config map[string]any, proxyMap map[string]C.Proxy, providersMap map[string]types.ProxyProvider) (C.ProxyAdapter, error) {

--- a/adapter/outboundgroup/relay.go
+++ b/adapter/outboundgroup/relay.go
@@ -191,6 +191,7 @@ func NewRelay(option *GroupCommonOption, providers []provider.ProxyProvider) *Re
 			},
 			"",
 			"",
+            "",
 			providers,
 		}),
 	}

--- a/adapter/outboundgroup/selector.go
+++ b/adapter/outboundgroup/selector.go
@@ -100,6 +100,7 @@ func NewSelector(option *GroupCommonOption, providers []provider.ProxyProvider) 
 			},
 			option.Filter,
 			option.ExcludeFilter,
+            option.ExcludeType,
 			providers,
 		}),
 		selected:   "COMPATIBLE",

--- a/adapter/outboundgroup/urltest.go
+++ b/adapter/outboundgroup/urltest.go
@@ -144,6 +144,7 @@ func NewURLTest(option *GroupCommonOption, providers []provider.ProxyProvider, o
 
 			option.Filter,
 			option.ExcludeFilter,
+            option.ExcludeType,
 			providers,
 		}),
 		fastSingle: singledo.NewSingle[C.Proxy](time.Second * 10),

--- a/adapter/provider/parser.go
+++ b/adapter/provider/parser.go
@@ -27,6 +27,7 @@ type proxyProviderSchema struct {
 	Interval      int               `provider:"interval,omitempty"`
 	Filter        string            `provider:"filter,omitempty"`
 	ExcludeFilter string            `provider:"exclude-filter,omitempty"`
+    ExcludeType   string            `provider:"exclude-type,omitempty"`
 	HealthCheck   healthCheckSchema `provider:"health-check,omitempty"`
 }
 
@@ -63,5 +64,7 @@ func ParseProxyProvider(name string, mapping map[string]any) (types.ProxyProvide
 	interval := time.Duration(uint(schema.Interval)) * time.Second
 	filter := schema.Filter
 	excludeFilter := schema.ExcludeFilter
-	return NewProxySetProvider(name, interval, filter, excludeFilter, vehicle, hc)
+    excludeType:=schema.ExcludeType
+
+	return NewProxySetProvider(name, interval, filter, excludeFilter,excludeType,vehicle, hc)
 }

--- a/adapter/provider/provider.go
+++ b/adapter/provider/provider.go
@@ -141,11 +141,16 @@ func stopProxyProvider(pd *ProxySetProvider) {
 	_ = pd.Fetcher.Destroy()
 }
 
-func NewProxySetProvider(name string, interval time.Duration, filter string, excludeFilter string, vehicle types.Vehicle, hc *HealthCheck) (*ProxySetProvider, error) {
+func NewProxySetProvider(name string, interval time.Duration, filter string, excludeFilter string,excludeType string, vehicle types.Vehicle, hc *HealthCheck) (*ProxySetProvider, error) {
 	excludeFilterReg, err := regexp2.Compile(excludeFilter, 0)
 	if err != nil {
 		return nil, fmt.Errorf("invalid excludeFilter regex: %w", err)
 	}
+    var excludeTypeArray []string
+    if excludeType !=""{
+        excludeTypeArray=strings.Split(excludeType,"|")
+    }
+
 	var filterRegs []*regexp2.Regexp
 	for _, filter := range strings.Split(filter, "`") {
 		filterReg, err := regexp2.Compile(filter, 0)
@@ -164,7 +169,7 @@ func NewProxySetProvider(name string, interval time.Duration, filter string, exc
 		healthCheck: hc,
 	}
 
-	fetcher := resource.NewFetcher[[]C.Proxy](name, interval, vehicle, proxiesParseAndFilter(filter, excludeFilter, filterRegs, excludeFilterReg), proxiesOnUpdate(pd))
+	fetcher := resource.NewFetcher[[]C.Proxy](name, interval, vehicle, proxiesParseAndFilter(filter, excludeFilter, excludeTypeArray,filterRegs, excludeFilterReg), proxiesOnUpdate(pd))
 	pd.Fetcher = fetcher
 
 	pd.getSubscriptionInfo()
@@ -262,7 +267,7 @@ func proxiesOnUpdate(pd *proxySetProvider) func([]C.Proxy) {
 	}
 }
 
-func proxiesParseAndFilter(filter string, excludeFilter string, filterRegs []*regexp2.Regexp, excludeFilterReg *regexp2.Regexp) resource.Parser[[]C.Proxy] {
+func proxiesParseAndFilter(filter string, excludeFilter string,excludeTypeArray []string, filterRegs []*regexp2.Regexp, excludeFilterReg *regexp2.Regexp) resource.Parser[[]C.Proxy] {
 	return func(buf []byte) ([]C.Proxy, error) {
 		schema := &ProxySchema{}
 
@@ -282,6 +287,27 @@ func proxiesParseAndFilter(filter string, excludeFilter string, filterRegs []*re
 		proxiesSet := map[string]struct{}{}
 		for _, filterReg := range filterRegs {
 			for idx, mapping := range schema.Proxies {
+                if nil !=excludeTypeArray && len(excludeTypeArray)>0{
+                    mType,ok:=mapping["type"]
+                    if !ok {
+                        continue
+                    }
+                    pType,ok:=mType.(string)
+                    if !ok {
+                        continue
+                    }
+                    flag:=false
+                    for i := range excludeTypeArray {
+                        if(strings.EqualFold(pType,excludeTypeArray[i])){
+                            flag=true
+                        }
+
+                    }
+                    if(flag){
+                        continue
+                    }
+
+                }
 				mName, ok := mapping["name"]
 				if !ok {
 					continue

--- a/common/convert/converter.go
+++ b/common/convert/converter.go
@@ -162,8 +162,11 @@ func ConvertsV2Ray(buf []byte) ([]map[string]any, error) {
 			if jsonDc.Decode(&values) != nil {
 				continue
 			}
-
-			name := uniqueName(names, values["ps"].(string))
+            tempName,ok:=values["ps"].(string)
+            if !ok{
+                continue
+            }
+			name := uniqueName(names, tempName)
 			vmess := make(map[string]any, 20)
 
 			vmess["name"] = name


### PR DESCRIPTION
proxy-provider 和proxy-groups 支持通过节点类型排除
proxy-provider and proxy-groups support exclude node by node type


proxy-provider example:

```yaml
proxy-providers:
  xxxxx:
    type: http
    url: xxxxxx
    path: xxx
    #filter: "xxx"  #支持正则表达式根据节点名称筛选
    #exclude-filter: "xxx" #支持正则表达式根据节点名称排除
    exclude-type: "ss|http" #不支持正则表达式，通过 "|" 分割，根据节点类型排除
    interval: 3600
    health-check:
      enable: true
      url: http://www.gstatic.com/generate_204
      interval: 3600

```
proxy-groups example:
https://github.com/MetaCubeX/Clash.Meta/blob/Alpha/constant/adapters.go
```yaml
proxy-groups:
  - name: XXX
    type: url-test
    #filter: "xxx" #支持正则表达式根据节点名称筛选
    #exclude-filter: "xxx" #支持正则表达式根据节点名称排除
    exclude-type: "Shadowsocks|Http" #不支持正则表达式，通过 "|" 分割，根据节点类型排除,注意，名称与proxy-providers不同
    use:
      -xxxxx
    proxies:
      - xxxx
    # tolerance: 150
    # lazy: true
    url: "http://www.gstatic.com/generate_204"
    interval: 300

```

