### PR TITLE
fix #322: add option general.find-process-mode, user can turn off findProcess feature in router

### DIFF
--- a/component/process/find_process_mode.go
+++ b/component/process/find_process_mode.go
@@ -1,0 +1,57 @@
+package process
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+const (
+	FindProcessAlways = "always"
+	FindProcessStrict = "strict"
+	FindProcessOff    = "off"
+)
+
+var (
+	validModes = map[string]struct{}{
+		FindProcessAlways: {},
+		FindProcessOff:    {},
+		FindProcessStrict: {},
+	}
+)
+
+type FindProcessMode string
+
+func (m FindProcessMode) Always() bool {
+	return m == FindProcessAlways
+}
+
+func (m FindProcessMode) Off() bool {
+	return m == FindProcessOff
+}
+
+func (m *FindProcessMode) UnmarshalYAML(unmarshal func(any) error) error {
+	var tp string
+	if err := unmarshal(&tp); err != nil {
+		return err
+	}
+	return m.Set(tp)
+}
+
+func (m *FindProcessMode) UnmarshalJSON(data []byte) error {
+	var tp string
+	if err := json.Unmarshal(data, &tp); err != nil {
+		return err
+	}
+	return m.Set(tp)
+}
+
+func (m *FindProcessMode) Set(value string) error {
+	mode := strings.ToLower(value)
+	_, exist := validModes[mode]
+	if !exist {
+		return errors.New("invalid find process mode")
+	}
+	*m = FindProcessMode(mode)
+	return nil
+}

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -309,7 +309,7 @@ func updateTunnels(tunnels []LC.Tunnel) {
 
 func updateGeneral(general *config.General, force bool) {
 	tunnel.SetMode(general.Mode)
-	tunnel.SetAlwaysFindProcess(general.EnableProcess)
+	tunnel.SetFindProcessMode(general.EnableProcess, general.FindProcessMode)
 	dialer.DisableIPv6 = !general.IPv6
 	if !dialer.DisableIPv6 {
 		log.Infoln("Use IPv6")


### PR DESCRIPTION
findProcess slow down connection due to repeat call to FindProcessName in router environment this option has 3 values: always, strict, off
- always, equal to enable-process: true. Just try to merge all process related option into one
- strict, as default value, behavior remains unchanged
- off, turn off findProcess, useful in router environment