### PR TITLE
修复无法使用IPv6节点的问题

### DIFF
--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -161,7 +161,7 @@ func updateDNS(c *config.DNS, generalIPv6 bool) {
 		dns.ReCreateServer("", nil, nil)
 		return
 	} else {
-		resolver.DisableIPv6 = !c.IPv6
+		resolver.DisableIPv6 = !(c.IPv6 || generalIPv6)
 	}
 
 	cfg := dns.Config{


### PR DESCRIPTION
当全局IPv6开关开启，且启用了DNS，并禁止DNS对外解析AAAA的情况下，会导致IPv6的节点无法使用。
症状表现为，不管配置节点为IPv6地址，还是有AAAA记录的域名，都会提示如下错误。
```
WARN[0006] [TCP] dial GLOBAL *.*.*.*:**** --> ***.com:*** error: [****:****:****:****::****]:**** connect error: ip version error 
```
经检查是由于意外的关闭了Resolver的IPv6解析所致。