### PR TITLE
chore: better ipv6 dns server parse

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/Dreamacro/clash/constant/features"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
+
+	"github.com/Dreamacro/clash/constant/features"
 
 	"github.com/Dreamacro/clash/config"
 	C "github.com/Dreamacro/clash/constant"


### PR DESCRIPTION
在解析ipv6格式的dns有点麻烦，因为原本没有写符合一般ipv6的格式解析，比如
```
    nameserver:
        - '2400:3200:baba::1'
 ```
在原本是不能通过的，必须是
```
    nameserver:
        - '[2400:3200:baba::1]:53'
```

这对不少人来说有点费解，现在ipv6格式的dns也支持默认端口了

然后顺便优化了一点https的dns地址解析的代码