### PR TITLE
修复TPROXY处理UDP时的问题

### DIFF
--- a/component/nat/table.go
+++ b/component/nat/table.go
@@ -1,6 +1,7 @@
 package nat
 
 import (
+	"net"
 	"sync"
 
 	C "github.com/Dreamacro/clash/constant"
@@ -10,16 +11,24 @@ type Table struct {
 	mapping sync.Map
 }
 
-func (t *Table) Set(key string, pc C.PacketConn) {
-	t.mapping.Store(key, pc)
+type Entry struct {
+	PacketConn      C.PacketConn
+	LocalUDPConnMap sync.Map
+}
+
+func (t *Table) Set(key string, e C.PacketConn) {
+	t.mapping.Store(key, &Entry{
+		PacketConn:      e,
+		LocalUDPConnMap: sync.Map{},
+	})
 }
 
 func (t *Table) Get(key string) C.PacketConn {
-	item, exist := t.mapping.Load(key)
+	entry, exist := t.getEntry(key)
 	if !exist {
 		return nil
 	}
-	return item.(C.PacketConn)
+	return entry.PacketConn
 }
 
 func (t *Table) GetOrCreateLock(key string) (*sync.Cond, bool) {
@@ -29,6 +38,62 @@ func (t *Table) GetOrCreateLock(key string) (*sync.Cond, bool) {
 
 func (t *Table) Delete(key string) {
 	t.mapping.Delete(key)
+}
+
+func (t *Table) GetLocalConn(lAddr, rAddr string) *net.UDPConn {
+	entry, exist := t.getEntry(lAddr)
+	if !exist {
+		return nil
+	}
+	item, exist := entry.LocalUDPConnMap.Load(rAddr)
+	if !exist {
+		return nil
+	}
+	return item.(*net.UDPConn)
+}
+
+func (t *Table) AddLocalConn(lAddr, rAddr string, conn *net.UDPConn) bool {
+	entry, exist := t.getEntry(lAddr)
+	if !exist {
+		return false
+	}
+	entry.LocalUDPConnMap.Store(rAddr, conn)
+	return true
+}
+
+func (t *Table) RangeLocalConn(lAddr string, f func(key, value any) bool) {
+	entry, exist := t.getEntry(lAddr)
+	if !exist {
+		return
+	}
+	entry.LocalUDPConnMap.Range(f)
+}
+
+func (t *Table) GetOrCreateLockForLocalConn(lAddr, key string) (*sync.Cond, bool) {
+	entry, loaded := t.getEntry(lAddr)
+	if !loaded {
+		return nil, false
+	}
+	item, loaded := entry.LocalUDPConnMap.LoadOrStore(key, sync.NewCond(&sync.Mutex{}))
+	return item.(*sync.Cond), loaded
+}
+
+func (t *Table) DeleteLocalConnMap(lAddr, key string) {
+	entry, loaded := t.getEntry(lAddr)
+	if !loaded {
+		return
+	}
+	entry.LocalUDPConnMap.Delete(key)
+}
+
+func (t *Table) getEntry(key string) (*Entry, bool) {
+	item, ok := t.mapping.Load(key)
+	// This should not happen usually since this function called after PacketConn created
+	if !ok {
+		return nil, false
+	}
+	entry, ok := item.(*Entry)
+	return entry, ok
 }
 
 // New return *Cache

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"sync"
 	"time"
 
 	"github.com/Dreamacro/clash/component/dialer"
@@ -216,6 +217,10 @@ type UDPPacket interface {
 
 	// LocalAddr returns the source IP/Port of packet
 	LocalAddr() net.Addr
+
+	SetNatTable(natTable NatTable)
+
+	SetUdpInChan(in chan<- PacketAdapter)
 }
 
 type UDPPacketInAddr interface {
@@ -226,4 +231,24 @@ type UDPPacketInAddr interface {
 type PacketAdapter interface {
 	UDPPacket
 	Metadata() *Metadata
+}
+
+type NatTable interface {
+	Set(key string, e PacketConn)
+
+	Get(key string) PacketConn
+
+	GetOrCreateLock(key string) (*sync.Cond, bool)
+
+	Delete(key string)
+
+	GetLocalConn(lAddr, rAddr string) *net.UDPConn
+
+	AddLocalConn(lAddr, rAddr string, conn *net.UDPConn) bool
+
+	RangeLocalConn(lAddr string, f func(key, value any) bool)
+
+	GetOrCreateLockForLocalConn(lAddr, key string) (*sync.Cond, bool)
+
+	DeleteLocalConnMap(lAddr, key string)
 }

--- a/listener/shadowsocks/utils.go
+++ b/listener/shadowsocks/utils.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	"github.com/Dreamacro/clash/common/pool"
+	C "github.com/Dreamacro/clash/constant"
 	"github.com/Dreamacro/clash/transport/socks5"
 )
 
@@ -44,6 +45,13 @@ func (c *packet) InAddr() net.Addr {
 	return c.pc.LocalAddr()
 }
 
+func (c *packet) SetNatTable(natTable C.NatTable) {
+	// no need
+}
+
+func (c *packet) SetUdpInChan(in chan<- C.PacketAdapter) {
+	// no need
+}
 func ParseSSURL(s string) (addr, cipher, password string, err error) {
 	u, err := url.Parse(s)
 	if err != nil {

--- a/listener/sing/sing.go
+++ b/listener/sing/sing.go
@@ -166,3 +166,11 @@ func (c *packet) Drop() {
 func (c *packet) InAddr() net.Addr {
 	return c.lAddr
 }
+
+func (c *packet) SetNatTable(natTable C.NatTable) {
+	// no need
+}
+
+func (c *packet) SetUdpInChan(in chan<- C.PacketAdapter) {
+	// no need
+}

--- a/listener/socks/utils.go
+++ b/listener/socks/utils.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	"github.com/Dreamacro/clash/common/pool"
+	C "github.com/Dreamacro/clash/constant"
 	"github.com/Dreamacro/clash/transport/socks5"
 )
 
@@ -38,4 +39,12 @@ func (c *packet) Drop() {
 
 func (c *packet) InAddr() net.Addr {
 	return c.pc.LocalAddr()
+}
+
+func (c *packet) SetNatTable(natTable C.NatTable) {
+	// no need
+}
+
+func (c *packet) SetUdpInChan(in chan<- C.PacketAdapter) {
+	// no need
 }

--- a/listener/tproxy/packet.go
+++ b/listener/tproxy/packet.go
@@ -1,16 +1,22 @@
 package tproxy
 
 import (
+	"errors"
+	"fmt"
+	"github.com/Dreamacro/clash/adapter/inbound"
+	"github.com/Dreamacro/clash/common/pool"
+	C "github.com/Dreamacro/clash/constant"
+	"github.com/Dreamacro/clash/log"
 	"net"
 	"net/netip"
-
-	"github.com/Dreamacro/clash/common/pool"
 )
 
 type packet struct {
-	pc    net.PacketConn
-	lAddr netip.AddrPort
-	buf   []byte
+	pc       net.PacketConn
+	lAddr    netip.AddrPort
+	buf      []byte
+	natTable C.NatTable
+	in       chan<- C.PacketAdapter
 }
 
 func (c *packet) Data() []byte {
@@ -19,13 +25,12 @@ func (c *packet) Data() []byte {
 
 // WriteBack opens a new socket binding `addr` to write UDP packet back
 func (c *packet) WriteBack(b []byte, addr net.Addr) (n int, err error) {
-	tc, err := dialUDP("udp", addr.(*net.UDPAddr).AddrPort(), c.lAddr)
+	tc, err := createOrGetLocalConn(addr, c.LocalAddr(), c.natTable, c.in)
 	if err != nil {
 		n = 0
 		return
 	}
 	n, err = tc.Write(b)
-	tc.Close()
 	return
 }
 
@@ -40,4 +45,83 @@ func (c *packet) Drop() {
 
 func (c *packet) InAddr() net.Addr {
 	return c.pc.LocalAddr()
+}
+
+func (c *packet) SetNatTable(natTable C.NatTable) {
+	c.natTable = natTable
+}
+
+func (c *packet) SetUdpInChan(in chan<- C.PacketAdapter) {
+	c.in = in
+}
+
+// this function listen at rAddr and write to lAddr
+// for here, rAddr is the ip/port client want to access
+// lAddr is the ip/port client opened
+func createOrGetLocalConn(rAddr, lAddr net.Addr, natTable C.NatTable, in chan<- C.PacketAdapter) (*net.UDPConn, error) {
+	remote := rAddr.String()
+	local := lAddr.String()
+	localConn := natTable.GetLocalConn(local, remote)
+	// localConn not exist
+	if localConn == nil {
+		lockKey := remote + "-lock"
+		cond, loaded := natTable.GetOrCreateLockForLocalConn(local, lockKey)
+		if loaded {
+			cond.L.Lock()
+			cond.Wait()
+			// we should get localConn here
+			localConn = natTable.GetLocalConn(local, remote)
+			if localConn == nil {
+				return nil, fmt.Errorf("localConn is nil, nat entry not exist")
+			}
+			cond.L.Unlock()
+		} else {
+			if cond == nil {
+				return nil, fmt.Errorf("cond is nil, nat entry not exist")
+			}
+			defer func() {
+				natTable.DeleteLocalConnMap(local, lockKey)
+				cond.Broadcast()
+			}()
+			conn, err := listenLocalConn(rAddr, lAddr, in)
+			if err != nil {
+				log.Errorln("listenLocalConn failed with error: %s, packet loss", err.Error())
+				return nil, err
+			}
+			natTable.AddLocalConn(local, remote, conn)
+			localConn = conn
+		}
+	}
+	return localConn, nil
+}
+
+// this function listen at rAddr
+// and send what received to program itself, then send to real remote
+func listenLocalConn(rAddr, lAddr net.Addr, in chan<- C.PacketAdapter) (*net.UDPConn, error) {
+	additions := []inbound.Addition{
+		inbound.WithInName("DEFAULT-TPROXY"),
+		inbound.WithSpecialRules(""),
+	}
+	lc, err := dialUDP("udp", rAddr.(*net.UDPAddr).AddrPort(), lAddr.(*net.UDPAddr).AddrPort())
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		log.Debugln("TProxy listenLocalConn rAddr=%s lAddr=%s", rAddr.String(), lAddr.String())
+		for {
+			buf := pool.Get(pool.UDPBufferSize)
+			br, err := lc.Read(buf)
+			if err != nil {
+				pool.Put(buf)
+				if errors.Is(err, net.ErrClosed) {
+					log.Debugln("TProxy local conn listener exit.. rAddr=%s lAddr=%s", rAddr.String(), lAddr.String())
+					return
+				}
+			}
+			// since following localPackets are pass through this socket which listen rAddr
+			// I choose current listener as packet's packet conn
+			handlePacketConn(lc, in, buf[:br], lAddr.(*net.UDPAddr).AddrPort(), rAddr.(*net.UDPAddr).AddrPort(), additions...)
+		}
+	}()
+	return lc, nil
 }

--- a/listener/tunnel/packet.go
+++ b/listener/tunnel/packet.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	"github.com/Dreamacro/clash/common/pool"
+	C "github.com/Dreamacro/clash/constant"
 )
 
 type packet struct {
@@ -32,4 +33,12 @@ func (c *packet) Drop() {
 
 func (c *packet) InAddr() net.Addr {
 	return c.pc.LocalAddr()
+}
+
+func (c *packet) SetNatTable(natTable C.NatTable) {
+	// no need
+}
+
+func (c *packet) SetUdpInChan(in chan<- C.PacketAdapter) {
+	// no need
 }

--- a/transport/tuic/server.go
+++ b/transport/tuic/server.go
@@ -316,5 +316,13 @@ func (s *serverUDPPacket) Drop() {
 	s.packet.DATA = nil
 }
 
+func (s *serverUDPPacket) SetNatTable(natTable C.NatTable) {
+	// no need
+}
+
+func (s *serverUDPPacket) SetUdpInChan(in chan<- C.PacketAdapter) {
+	// no need
+}
+
 var _ C.UDPPacket = &serverUDPPacket{}
 var _ C.UDPPacketInAddr = &serverUDPPacket{}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -337,9 +337,12 @@ func handleUDPConn(packet C.PacketAdapter) {
 		}
 
 		oAddr := metadata.DstIP
+		natTable.Set(key, pc)
+		packet.SetNatTable(natTable)
+		packet.SetUdpInChan(udpQueue)
+
 		go handleUDPToLocal(packet, pc, key, oAddr, fAddr)
 
-		natTable.Set(key, pc)
 		handle()
 	}()
 }


### PR DESCRIPTION
## 概述

目前Clash处理TPROXY时采用不断开启/关闭本地Socket模式处理，导致在Socket开启时的分组丢失，从而产生了很多问题，这个补丁修复了这个问题，并增加了一定的性能（UDP双向测试时CPU从25%下降到15%）。

## 原因

TPROXY模块在Linux内核中实现时做了优化，对已经存在Transparent Socket的链接会直接使用而不会继续重定向；不断开启关闭Socks会导致不必要的性能消耗，同时也会导致Socks存在时的系统的UDP分组丢失（因为没有读取）。

## 存在的问题

目前遇到的比较严重的问题

- 单核心设备使用TPROXY处理Wireguard（包括其他内核模块也有类似问题）时，TCP断流、无法正常使用
- 单核心设备在双向UDP通信时，随机丢包
- TPROXY的UDP性能差，对比V2RAY等软件，在同等负载下即使是Direct内网环境下，CPU/延迟/丢包抖动等指标均不理想；且随机性丢包和延迟问题较为明显
- 多核心设备使用TPROXY处理Wireguard时，虽然能缓解TCP断流的问题，依然存在大量的TCP重传，非常影响性能，同时也不稳定

## 复现

复现方法较为简单，可以直接采用最容易复现的Wireguard，以下测试基于以下环境测试

1.在Vultr创建两台同区域的服务器，我选择1 Core款任意配置
2.安装最新版Wireguard/iperf3，并设置妥当；其中主动链接一方使用TPROXY重定向、作为iperf3客户端
3.设置好iptables tproxy规则
4.分别上传Alpha版的Clash.Meta和补丁后的Clash.Meta
5.设置Clash为Direct模式
6.使用Wireguard的端内IP执行iperf3测试

因为Wireguard为纯UDP协议，所以产生的隧道流量都会被重新组装为UDP。

两台服务器都在一个区域，可以视作内网测试。理想的测试结果应接近带宽极限或是CPU极限；UDP测试为10Mbps，此时就可以看出问题了，不需要再增加流量了。

### 原版Clash.Meta Wireguard测试结果

#### TCP接收测试（断流）

```
root@vultr:~# iperf3 -c 10.99.99.1 -R
Connecting to host 10.99.99.1, port 5201
Reverse mode, remote host 10.99.99.1 is sending
[  5] local 10.99.99.2 port 42448 connected to 10.99.99.1 port 5201
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec   178 KBytes  1.46 Mbits/sec                  
[  5]   1.00-2.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   2.00-3.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   3.00-4.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   4.00-5.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   5.00-6.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   6.00-7.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   7.00-8.00   sec   143 KBytes  1.17 Mbits/sec                  
[  5]   8.00-9.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5]   9.00-10.00  sec  0.00 Bytes  0.00 bits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.04  sec  1.23 MBytes  1.03 Mbits/sec    9             sender
[  5]   0.00-10.00  sec   321 KBytes   263 Kbits/sec                  receiver
```

#### TCP发送测试（大量重传/丢包/存在断流）

```
root@vultr:~# iperf3 -c 10.99.99.1
Connecting to host 10.99.99.1, port 5201
[  5] local 10.99.99.2 port 59330 connected to 10.99.99.1 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  1.41 MBytes  11.8 Mbits/sec  450   4.88 KBytes       
[  5]   1.00-2.00   sec  1014 KBytes  8.31 Mbits/sec  386   4.88 KBytes       
[  5]   2.00-3.00   sec  1.92 MBytes  16.1 Mbits/sec  626   1.22 KBytes       
[  5]   3.00-4.00   sec  0.00 Bytes  0.00 bits/sec   56   4.88 KBytes       
[  5]   4.00-5.00   sec  1014 KBytes  8.31 Mbits/sec  285   11.0 KBytes       
[  5]   5.00-6.00   sec   254 KBytes  2.08 Mbits/sec  107   4.88 KBytes       
[  5]   6.00-7.00   sec   697 KBytes  5.71 Mbits/sec  254   6.09 KBytes       
[  5]   7.00-8.00   sec  0.00 Bytes  0.00 bits/sec   18   7.31 KBytes       
[  5]   8.00-9.00   sec   190 KBytes  1.56 Mbits/sec    0   7.31 KBytes       
[  5]   9.00-10.00  sec  0.00 Bytes  0.00 bits/sec    0   7.31 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  6.42 MBytes  5.39 Mbits/sec  2182             sender
[  5]   0.00-10.04  sec  5.98 MBytes  5.00 Mbits/sec                  receiver
```

#### 双向TCP测试（断流）

```
root@vultr:~# iperf3 -c 10.99.99.1  --bidir
Connecting to host 10.99.99.1, port 5201
[  5] local 10.99.99.2 port 38572 connected to 10.99.99.1 port 5201
[  7] local 10.99.99.2 port 38576 connected to 10.99.99.1 port 5201
[ ID][Role] Interval           Transfer     Bitrate         Retr  Cwnd
[  5][TX-C]   0.00-1.00   sec  1.20 MBytes  10.1 Mbits/sec  379   3.66 KBytes       
[  7][RX-C]   0.00-1.00   sec   103 KBytes   843 Kbits/sec                  
[  5][TX-C]   1.00-2.00   sec  1014 KBytes  8.31 Mbits/sec  458   4.88 KBytes       
[  7][RX-C]   1.00-2.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5][TX-C]   2.00-3.00   sec  1.49 MBytes  12.5 Mbits/sec  557   6.09 KBytes       
[  7][RX-C]   2.00-3.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5][TX-C]   3.00-4.00   sec   951 KBytes  7.79 Mbits/sec  302   7.31 KBytes       
[  7][RX-C]   3.00-4.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5][TX-C]   4.00-5.00   sec  1.61 MBytes  13.5 Mbits/sec  634   8.53 KBytes       
[  7][RX-C]   4.00-5.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5][TX-C]   5.00-6.00   sec  0.00 Bytes  0.00 bits/sec   41   4.88 KBytes       
[  7][RX-C]   5.00-6.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5][TX-C]   6.00-7.00   sec   634 KBytes  5.19 Mbits/sec  155   4.88 KBytes       
[  7][RX-C]   6.00-7.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5][TX-C]   7.00-8.00   sec  0.00 Bytes  0.00 bits/sec   25   9.75 KBytes       
[  7][RX-C]   7.00-8.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5][TX-C]   8.00-9.00   sec  0.00 Bytes  0.00 bits/sec    0   9.75 KBytes       
[  7][RX-C]   8.00-9.00   sec  0.00 Bytes  0.00 bits/sec                  
[  5][TX-C]   9.00-10.00  sec   127 KBytes  1.04 Mbits/sec    0   9.75 KBytes       
[  7][RX-C]   9.00-10.00  sec  0.00 Bytes  0.00 bits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID][Role] Interval           Transfer     Bitrate         Retr
[  5][TX-C]   0.00-10.00  sec  6.96 MBytes  5.84 Mbits/sec  2551             sender
[  5][TX-C]   0.00-10.04  sec  6.62 MBytes  5.53 Mbits/sec                  receiver
[  7][RX-C]   0.00-10.00  sec   364 KBytes   299 Kbits/sec    6             sender
[  7][RX-C]   0.00-10.04  sec   103 KBytes  84.0 Kbits/sec                  receiver
```

#### 双向UDP测试（不稳定随机丢包+抖动）

```
root@vultr:~# iperf3 -c 10.99.99.1 --udp --bidir -b 10m
Connecting to host 10.99.99.1, port 5201
[  5] local 10.99.99.2 port 42538 connected to 10.99.99.1 port 5201
[  7] local 10.99.99.2 port 60777 connected to 10.99.99.1 port 5201
[ ID][Role] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5][TX-C]   0.00-1.00   sec  1.19 MBytes  9.99 Mbits/sec            1001  
[  7][RX-C]   0.00-1.00   sec  1.24 MBytes  10.4 Mbits/sec  0.059 ms  0/1043 (0%)  
[  5][TX-C]   1.00-2.00   sec  1.19 MBytes  10.0 Mbits/sec            1002  
[  7][RX-C]   1.00-2.00   sec  1.19 MBytes  10.0 Mbits/sec  0.134 ms  0/1002 (0%)  
[  5][TX-C]   2.00-3.00   sec  1.19 MBytes  9.99 Mbits/sec            1001  
[  7][RX-C]   2.00-3.00   sec  1.19 MBytes  9.99 Mbits/sec  0.085 ms  0/1001 (0%)  
[  5][TX-C]   3.00-4.00   sec  1.19 MBytes  10.0 Mbits/sec            1002  
[  7][RX-C]   3.00-4.00   sec  1.19 MBytes  10.0 Mbits/sec  0.092 ms  0/1002 (0%)  
[  5][TX-C]   4.00-5.00   sec  1.19 MBytes  10.0 Mbits/sec            1002  
[  7][RX-C]   4.00-5.00   sec  1.19 MBytes  10.0 Mbits/sec  0.085 ms  0/1002 (0%)  
[  5][TX-C]   5.00-6.00   sec  1.19 MBytes  9.99 Mbits/sec            1001  
[  7][RX-C]   5.00-6.00   sec  1.19 MBytes  9.99 Mbits/sec  0.103 ms  0/1001 (0%)  
[  5][TX-C]   6.00-7.00   sec  1.19 MBytes  10.0 Mbits/sec            1002  
[  7][RX-C]   6.00-7.00   sec  1.19 MBytes  10.0 Mbits/sec  0.096 ms  0/1003 (0%)  
[  5][TX-C]   7.00-8.00   sec  1.19 MBytes  9.99 Mbits/sec            1001  
[  7][RX-C]   7.00-8.00   sec  1.19 MBytes  9.99 Mbits/sec  0.084 ms  0/1001 (0%)  
[  5][TX-C]   8.00-9.00   sec  1.19 MBytes  10.0 Mbits/sec            1002  
[  7][RX-C]   8.00-9.00   sec  1.19 MBytes  10.0 Mbits/sec  0.069 ms  0/1002 (0%)  
[  5][TX-C]   9.00-10.00  sec  1.19 MBytes  10.0 Mbits/sec            1002  
[  7][RX-C]   9.00-10.00  sec  1.19 MBytes  10.0 Mbits/sec  0.035 ms  0/1002 (0%)  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID][Role] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5][TX-C]   0.00-10.00  sec  11.9 MBytes  10.0 Mbits/sec  0.000 ms  0/10016 (0%)  sender
[  5][TX-C]   0.00-10.04  sec  9.35 MBytes  7.81 Mbits/sec  0.065 ms  2157/10016 (22%)  receiver
[  7][RX-C]   0.00-10.00  sec  12.0 MBytes  10.0 Mbits/sec  0.000 ms  0/10059 (0%)  sender
[  7][RX-C]   0.00-10.04  sec  12.0 MBytes  10.0 Mbits/sec  0.035 ms  0/10059 (0%)  receiver
```

### 修复后Clash Meta Wireguard测试结果

#### TCP接收测试（CPU受限）

```
root@vultr:~# iperf3 -c 10.99.99.1 -R
Connecting to host 10.99.99.1, port 5201
Reverse mode, remote host 10.99.99.1 is sending
[  5] local 10.99.99.2 port 49240 connected to 10.99.99.1 port 5201
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec  12.1 MBytes   101 Mbits/sec                  
[  5]   1.00-2.00   sec  11.5 MBytes  96.2 Mbits/sec                  
[  5]   2.00-3.00   sec  12.1 MBytes   101 Mbits/sec                  
[  5]   3.00-4.00   sec  12.3 MBytes   103 Mbits/sec                  
[  5]   4.00-5.00   sec  12.6 MBytes   106 Mbits/sec                  
[  5]   5.00-6.00   sec  12.4 MBytes   104 Mbits/sec                  
[  5]   6.00-7.00   sec  12.7 MBytes   107 Mbits/sec                  
[  5]   7.00-8.00   sec  11.4 MBytes  96.0 Mbits/sec                  
[  5]   8.00-9.00   sec  12.1 MBytes   101 Mbits/sec                  
[  5]   9.00-10.00  sec  11.4 MBytes  95.8 Mbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.04  sec   122 MBytes   102 Mbits/sec  4975             sender
[  5]   0.00-10.00  sec   121 MBytes   101 Mbits/sec                  receiver
```

#### TCP发送测试（CPU受限）

```
root@vultr:~# iperf3 -c 10.99.99.1 
Connecting to host 10.99.99.1, port 5201
[  5] local 10.99.99.2 port 46448 connected to 10.99.99.1 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  18.2 MBytes   152 Mbits/sec  611    210 KBytes       
[  5]   1.00-2.00   sec  19.2 MBytes   161 Mbits/sec   20    188 KBytes       
[  5]   2.00-3.00   sec  17.8 MBytes   150 Mbits/sec   81    214 KBytes       
[  5]   3.00-4.00   sec  20.0 MBytes   168 Mbits/sec   15    168 KBytes       
[  5]   4.00-5.00   sec  19.7 MBytes   166 Mbits/sec   44    139 KBytes       
[  5]   5.00-6.00   sec  19.1 MBytes   160 Mbits/sec    0    188 KBytes       
[  5]   6.00-7.00   sec  19.1 MBytes   160 Mbits/sec   69    183 KBytes       
[  5]   7.00-8.00   sec  19.2 MBytes   161 Mbits/sec   47    119 KBytes       
[  5]   8.00-9.00   sec  18.7 MBytes   157 Mbits/sec   29    166 KBytes       
[  5]   9.00-10.00  sec  18.3 MBytes   153 Mbits/sec  182   4.88 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   189 MBytes   159 Mbits/sec  1098             sender
[  5]   0.00-10.04  sec   188 MBytes   157 Mbits/sec                  receiver
```

#### TCP双向测试（CPU受限）

```
root@vultr:~# iperf3 -c 10.99.99.1 --bidir
Connecting to host 10.99.99.1, port 5201
[  5] local 10.99.99.2 port 49506 connected to 10.99.99.1 port 5201
[  7] local 10.99.99.2 port 49508 connected to 10.99.99.1 port 5201
[ ID][Role] Interval           Transfer     Bitrate         Retr  Cwnd
[  5][TX-C]   0.00-1.00   sec  14.8 MBytes   124 Mbits/sec  140    193 KBytes       
[  7][RX-C]   0.00-1.00   sec  4.30 MBytes  36.1 Mbits/sec                  
[  5][TX-C]   1.00-2.00   sec  16.6 MBytes   139 Mbits/sec   78    146 KBytes       
[  7][RX-C]   1.00-2.00   sec  4.57 MBytes  38.4 Mbits/sec                  
[  5][TX-C]   2.00-3.00   sec  16.6 MBytes   139 Mbits/sec  387    208 KBytes       
[  7][RX-C]   2.00-3.00   sec  4.89 MBytes  41.0 Mbits/sec                  
[  5][TX-C]   3.00-4.00   sec  18.3 MBytes   153 Mbits/sec  233    190 KBytes       
[  7][RX-C]   3.00-4.00   sec  3.37 MBytes  28.3 Mbits/sec                  
[  5][TX-C]   4.00-5.00   sec  17.5 MBytes   147 Mbits/sec  340    201 KBytes       
[  7][RX-C]   4.00-5.00   sec  3.10 MBytes  25.9 Mbits/sec                  
[  5][TX-C]   5.00-6.00   sec  18.7 MBytes   157 Mbits/sec  444    234 KBytes       
[  7][RX-C]   5.00-6.00   sec  2.57 MBytes  21.6 Mbits/sec                  
[  5][TX-C]   6.00-7.00   sec  20.4 MBytes   171 Mbits/sec  303    341 KBytes       
[  7][RX-C]   6.00-7.00   sec  2.80 MBytes  23.5 Mbits/sec                  
[  5][TX-C]   7.00-8.00   sec  19.4 MBytes   163 Mbits/sec  262    268 KBytes       
[  7][RX-C]   7.00-8.00   sec  2.62 MBytes  22.0 Mbits/sec                  
[  5][TX-C]   8.00-9.00   sec  18.4 MBytes   155 Mbits/sec  245    258 KBytes       
[  7][RX-C]   8.00-9.00   sec  2.39 MBytes  20.1 Mbits/sec                  
[  5][TX-C]   9.00-10.00  sec  19.1 MBytes   160 Mbits/sec  344   4.88 KBytes       
[  7][RX-C]   9.00-10.00  sec  2.31 MBytes  19.4 Mbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID][Role] Interval           Transfer     Bitrate         Retr
[  5][TX-C]   0.00-10.00  sec   180 MBytes   151 Mbits/sec  2776             sender
[  5][TX-C]   0.00-10.04  sec   178 MBytes   149 Mbits/sec                  receiver
[  7][RX-C]   0.00-10.00  sec  33.3 MBytes  27.9 Mbits/sec  300             sender
[  7][RX-C]   0.00-10.04  sec  32.9 MBytes  27.5 Mbits/sec                  receiver
```

#### UDP双向测试（不丢包）

```
root@vultr:~# iperf3 -c 10.99.99.1 --bidir --udp -b 10M
Connecting to host 10.99.99.1, port 5201
[  5] local 10.99.99.2 port 33796 connected to 10.99.99.1 port 5201
[  7] local 10.99.99.2 port 56405 connected to 10.99.99.1 port 5201
[ ID][Role] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5][TX-C]   0.00-1.00   sec  1.19 MBytes  9.99 Mbits/sec            1001  
[  7][RX-C]   0.00-1.00   sec  1.24 MBytes  10.4 Mbits/sec  0.040 ms  0/1040 (0%)  
[  5][TX-C]   1.00-2.00   sec  1.19 MBytes  10.0 Mbits/sec            1002  
[  7][RX-C]   1.00-2.00   sec  1.19 MBytes  10.0 Mbits/sec  0.036 ms  0/1002 (0%)  
[  5][TX-C]   2.00-3.00   sec  1.19 MBytes  9.99 Mbits/sec            1001  
[  7][RX-C]   2.00-3.00   sec  1.19 MBytes  9.99 Mbits/sec  0.037 ms  0/1001 (0%)  
[  5][TX-C]   3.00-4.00   sec  1.19 MBytes  10.0 Mbits/sec            1002  
[  7][RX-C]   3.00-4.00   sec  1.19 MBytes  10.0 Mbits/sec  0.037 ms  0/1002 (0%)  
[  5][TX-C]   4.00-5.00   sec  1.19 MBytes  10.0 Mbits/sec            1002  
[  7][RX-C]   4.00-5.00   sec  1.19 MBytes  10.0 Mbits/sec  0.054 ms  0/1002 (0%)  
[  5][TX-C]   5.00-6.00   sec  1.19 MBytes  9.99 Mbits/sec            1001  
[  7][RX-C]   5.00-6.00   sec  1.19 MBytes  9.99 Mbits/sec  0.040 ms  0/1001 (0%)  
[  5][TX-C]   6.00-7.00   sec  1.19 MBytes  10.0 Mbits/sec            1002  
[  7][RX-C]   6.00-7.00   sec  1.19 MBytes  10.0 Mbits/sec  0.057 ms  0/1002 (0%)  
[  5][TX-C]   7.00-8.00   sec  1.19 MBytes  9.99 Mbits/sec            1001  
[  7][RX-C]   7.00-8.00   sec  1.19 MBytes  9.99 Mbits/sec  0.070 ms  0/1001 (0%)  
[  5][TX-C]   8.00-9.00   sec  1.19 MBytes  10.0 Mbits/sec            1002  
[  7][RX-C]   8.00-9.00   sec  1.19 MBytes  10.0 Mbits/sec  0.058 ms  0/1002 (0%)  
[  5][TX-C]   9.00-10.00  sec  1.19 MBytes  10.0 Mbits/sec            1002  
[  7][RX-C]   9.00-10.00  sec  1.19 MBytes  10.0 Mbits/sec  0.030 ms  0/1002 (0%)  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID][Role] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5][TX-C]   0.00-10.00  sec  11.9 MBytes  10.0 Mbits/sec  0.000 ms  0/10016 (0%)  sender
[  5][TX-C]   0.00-10.04  sec  11.9 MBytes  9.96 Mbits/sec  0.060 ms  0/10016 (0%)  receiver
[  7][RX-C]   0.00-10.00  sec  12.0 MBytes  10.0 Mbits/sec  0.000 ms  0/10056 (0%)  sender
[  7][RX-C]   0.00-10.04  sec  12.0 MBytes  10.0 Mbits/sec  0.030 ms  0/10055 (0%)  receiver

```
