### PR TITLE
Fix: Enforce conn context 修复延迟测速耗时超过timeout

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Dreamacro/clash/common/queue"
 	"github.com/Dreamacro/clash/component/dialer"
 	C "github.com/Dreamacro/clash/constant"
+	"github.com/Dreamacro/clash/log"
 )
 
 var UnifiedDelay = atomic.NewBool(false)
@@ -125,6 +126,13 @@ func (p *Proxy) URLTest(ctx context.Context, url string) (t uint16, err error) {
 		return
 	}
 	defer func() {
+		if d, ok := ctx.Deadline(); ok {
+			actualElapsed := time.Since(start)
+			expectTimeout := d.Sub(start)
+			if actualElapsed > expectTimeout+time.Millisecond*100 {
+				log.Infoln("[URLTest]  %s(%s) timeout, expect: %s, actual: %s", p.Name(), p.Type(), expectTimeout, actualElapsed)
+			}
+		}
 		_ = instance.Close()
 	}()
 

--- a/adapter/outbound/hysteria.go
+++ b/adapter/outbound/hysteria.go
@@ -71,7 +71,7 @@ func (h *Hysteria) ListenPacketContext(ctx context.Context, metadata *C.Metadata
 
 func (h *Hysteria) genHdc(ctx context.Context, opts ...dialer.Option) utils.PacketDialer {
 	return &hyDialerWithContext{
-		ctx: context.Background(),
+		ctx: ctx,
 		hyDialer: func(network string) (net.PacketConn, error) {
 			var err error
 			var cDialer C.Dialer = dialer.NewDialer(h.Base.DialOptions(opts...)...)

--- a/adapter/outbound/socks5.go
+++ b/adapter/outbound/socks5.go
@@ -88,6 +88,9 @@ func (ss *Socks5) DialContextWithDialer(ctx context.Context, dialer C.Dialer, me
 		safeConnClose(c, err)
 	}(c)
 
+	release := enforceContextToConn(ctx, c)
+	defer release()
+
 	c, err = ss.StreamConn(c, metadata)
 	if err != nil {
 		return nil, err

--- a/adapter/outbound/trojan.go
+++ b/adapter/outbound/trojan.go
@@ -151,6 +151,9 @@ func (t *Trojan) DialContextWithDialer(ctx context.Context, dialer C.Dialer, met
 		safeConnClose(c, err)
 	}(c)
 
+	release := enforceContextToConn(ctx, c)
+	defer release()
+
 	c, err = t.StreamConn(c, metadata)
 	if err != nil {
 		return nil, err

--- a/adapter/outbound/util.go
+++ b/adapter/outbound/util.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	xtls "github.com/xtls/go"
 	"net"
 	"net/netip"
 	"strconv"
 	"sync"
 	"time"
+
+	xtls "github.com/xtls/go"
 
 	"github.com/Dreamacro/clash/component/resolver"
 	C "github.com/Dreamacro/clash/constant"
@@ -137,4 +138,19 @@ func safeConnClose(c net.Conn, err error) {
 	if err != nil && c != nil {
 		_ = c.Close()
 	}
+}
+
+// enforceContextToConn enforce context to a a connection
+func enforceContextToConn(ctx context.Context, conn net.Conn) (release func()) {
+	release = func() {}
+	deadline, ok := ctx.Deadline()
+	if ok {
+		// explicitly set deadline to conn
+		conn.SetDeadline(deadline)
+		return func() {
+			// set deadline to zero
+			conn.SetDeadline(time.Time{})
+		}
+	}
+	return release
 }

--- a/adapter/outbound/vmess.go
+++ b/adapter/outbound/vmess.go
@@ -294,6 +294,9 @@ func (v *Vmess) DialContextWithDialer(ctx context.Context, dialer C.Dialer, meta
 		safeConnClose(c, err)
 	}(c)
 
+	release := enforceContextToConn(ctx, c)
+	defer release()
+
 	c, err = v.StreamConn(c, metadata)
 	return NewConn(c, v), err
 }


### PR DESCRIPTION
延迟测速时(/api/delay)，经常会有超过设置timeout的情况。
比如yacd设置了2000ms timout，但是这个api耗费了5秒甚至10秒多才返回，很烦人。

原因是在各个协议协商阶段并没有设置context，且当连接在超时时间内建立，但是回包一直没有到达时(StreamConn方法)，测速会一直挂起。很难受。

此PR修复该问题。经测试，修复后前端调用该api的耗时稳定在期望的2秒。