### PR TITLE
fix hysteria faketcp lookback in TUN mode

### DIFF
--- a/component/dialer/bind.go
+++ b/component/dialer/bind.go
@@ -22,7 +22,7 @@ func LookupLocalAddrFromIfaceName(ifaceName string, network string, destination 
 		addr, err = ifaceObj.PickIPv6Addr(destination)
 	default:
 		if destination.IsValid() {
-			if destination.Is4() {
+			if destination.Is4() || destination.Is4In6() {
 				addr, err = ifaceObj.PickIPv4Addr(destination)
 			} else {
 				addr, err = ifaceObj.PickIPv6Addr(destination)

--- a/component/iface/iface.go
+++ b/component/iface/iface.go
@@ -35,8 +35,11 @@ func ResolveInterface(name string) (*Interface, error) {
 
 		for _, iface := range ifaces {
 			addrs, err := iface.Addrs()
-			//if err or not available device like Meta, dummy0, docker0, etc.
-			if (iface.Flags&net.FlagMulticast == 0) || (err != nil) || (iface.Flags&net.FlagPointToPoint != 0) || (iface.Flags&net.FlagRunning == 0) {
+			if err != nil {
+				continue
+			}
+			// if not available device like Meta, dummy0, docker0, etc.
+			if (iface.Flags&net.FlagMulticast == 0) || (iface.Flags&net.FlagPointToPoint != 0) || (iface.Flags&net.FlagRunning == 0) {
 				continue
 			}
 


### PR DESCRIPTION
在ArchLinux上测试通过
在Android上偶尔会报内存问题，由于对于项目架构不了解，该问题超出了本人能力范围，暂时无法解决

内存部分日志如下

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x644ae845e0]

goroutine 366 [running]:
github.com/Dreamacro/clash/adapter.(*Proxy).URLTest(0x4000506510, {0x644b86fba8?, 0x4000e4c7b0}, {0x4000048690, 0x23}, {0x0?, 0x0, 0x4000526000?}, 0x40000a7e08?)
 github.com/Dreamacro/clash/adapter/adapter.go:290 +0x550
github.com/Dreamacro/clash/adapter/provider.(*HealthCheck).execute.func1()
 github.com/Dreamacro/clash/adapter/provider/healthcheck.go:211 +0x17c
github.com/Dreamacro/clash/common/batch.(*Batch[...]).Go.func1()
 github.com/Dreamacro/clash/common/batch/batch.go:52 +0xec
created by github.com/Dreamacro/clash/common/batch.(*Batch[...]).Go
 github.com/Dreamacro/clash/common/batch/batch.go:43 +0xe0
```