### PR TITLE
[Feature] Check if storage is available before discarding data generated through the delay testing via REST API

### DIFF
--- a/adapter/provider/healthcheck.go
+++ b/adapter/provider/healthcheck.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	defaultURLTestTimeout = time.Second * 5
-	defaultMaxTestUrlNum  = 6
 )
 
 type HealthCheckOption struct {
@@ -105,8 +104,8 @@ func (hc *HealthCheck) registerHealthCheckTask(url string, expectedStatus utils.
 	}
 
 	// due to the time-consuming nature of health checks, a maximum of defaultMaxTestURLNum URLs can be set for testing
-	if len(hc.extra) > defaultMaxTestUrlNum {
-		log.Debugln("skip add url: %s to health check because it has reached the maximum limit: %d", url, defaultMaxTestUrlNum)
+	if len(hc.extra) > C.DefaultMaxHealthCheckUrlNum {
+		log.Debugln("skip add url: %s to health check because it has reached the maximum limit: %d", url, C.DefaultMaxHealthCheckUrlNum)
 		return
 	}
 
@@ -220,6 +219,11 @@ func (hc *HealthCheck) close() {
 }
 
 func NewHealthCheck(proxies []C.Proxy, url string, interval uint, lazy bool, expectedStatus utils.IntRanges[uint16]) *HealthCheck {
+	if len(url) == 0 {
+		interval = 0
+		expectedStatus = nil
+	}
+
 	return &HealthCheck{
 		proxies:        proxies,
 		url:            url,

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -41,9 +41,10 @@ const (
 )
 
 const (
-	DefaultTCPTimeout = 5 * time.Second
-	DefaultUDPTimeout = DefaultTCPTimeout
-	DefaultTLSTimeout = DefaultTCPTimeout
+	DefaultTCPTimeout           = 5 * time.Second
+	DefaultUDPTimeout           = DefaultTCPTimeout
+	DefaultTLSTimeout           = DefaultTCPTimeout
+	DefaultMaxHealthCheckUrlNum = 16
 )
 
 var ErrNotSupport = errors.New("no support")


### PR DESCRIPTION
+ When testing the delay through REST API, determine whether to store the delay data based on certain conditions instead of discarding it directly