### PR TITLE
chore:  修改 geodata 下载域名为 fastly.jsdelivr.net

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -417,9 +417,9 @@ func UnmarshalRawConfig(buf []byte) (*RawConfig, error) {
 			StoreSelected: true,
 		},
 		GeoXUrl: RawGeoXUrl{
-			Mmdb:    "https://testingcf.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/country.mmdb",
-			GeoIp:   "https://testingcf.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip.dat",
-			GeoSite: "https://testingcf.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geosite.dat",
+			Mmdb:    "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/country.mmdb",
+			GeoIp:   "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip.dat",
+			GeoSite: "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geosite.dat",
 		},
 	}
 


### PR DESCRIPTION
修改 geodata 下载域名为 fastly.jsdelivr.net，尝试解决 testingcf.jsdelivr.net 在大多数地区被污染无法使用的问题 ( 参见: https://github.com/MetaCubeX/ClashMetaForAndroid/issues/101 )