### PR TITLE
Improve: nicer tun info for RESTful api

### DIFF
--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -129,7 +129,7 @@ func GetGeneral() *config.General {
 			RedirPort:         ports.RedirPort,
 			TProxyPort:        ports.TProxyPort,
 			MixedPort:         ports.MixedPort,
-			Tun:               listener.GetTunConf(),
+			Tun:               listener.LastTunConf,
 			TuicServer:        listener.GetTuicConf(),
 			ShadowSocksConfig: ports.ShadowSocksConfig,
 			VmessConfig:       ports.VmessConfig,

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -516,6 +516,7 @@ func ReCreateTun(tunConf LC.Tun, tcpIn chan<- C.ConnContext, udpIn chan<- C.Pack
 	defer func() {
 		if err != nil {
 			log.Errorln("Start TUN listening error: %s", err.Error())
+			tunConf.Enable = false
 			Cleanup(false)
 		}
 	}()


### PR DESCRIPTION
Let the restful api still get TunConf even when tun is off. Otherwise the api will return the default values,
instead of the values that actually take effect after enable.

\* Due to this problem, yacd changes the displayed value back to gvisor immediately after the user selects tun stack.

---
[/listener/listener.go#L85-L92](https://github.com/MetaCubeX/Clash.Meta/blob/65071ea7d16724ef3262366f0c0877b4a73d815b/listener/listener.go#L85-L92)
```go
func GetTunConf() LC.Tun {
        if tunLister == nil {
                return LC.Tun{
                        Enable: false,
                }
        }
        return tunLister.Config()
}
```

The `GET /configs` interface currently returns the information provided by this function, and attributes other than `Enable` will be filled with default values. 

When the configuration of the tun is changed, the tun device will be automatically shut down, which means that any configuration of the tun cannot get status feedback.

The `listener.LastTunConf` records the configuration that is actually taking effect or waiting to take effect, and it is reasonable to return it as a response to the `GET /config` interface.

However, if the tun device fails to start, the first defer function in the following `ReCreateTun` function will restore the `LastTunConf` variable to the parameters received by the external function, making the `enable` status display inaccurate.

[/listener/listener.go#L508-L513](https://github.com/MetaCubeX/Clash.Meta/blob/65071ea7d16724ef3262366f0c0877b4a73d815b/listener/listener.go#L508-L513)
```go
func ReCreateTun(tunConf LC.Tun, tcpIn chan<- C.ConnContext, udpIn chan<- C.PacketAdapter) {
	tunMux.Lock()
	defer func() {
		LastTunConf = tunConf
		tunMux.Unlock()
	}()
	...
```

so an additional processing is required:

```patch
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -516,6 +516,7 @@ func ReCreateTun(tunConf LC.Tun, tcpIn chan<- C.ConnContext, udpIn chan<- C.Pack
        defer func() {
                if err != nil {
                        log.Errorln("Start TUN listening error: %s", err.Error())
+                       tunConf.Enable = false
                        Cleanup(false)
                }
        }()
```

---
_The tuic-server faces the same problem, but currently there is no front-end that can configure it._