### PR TITLE
fix: call shutdown() before restart

### DIFF
--- a/hub/route/restart.go
+++ b/hub/route/restart.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"syscall"
 
-	"github.com/Dreamacro/clash/listener"
+	"github.com/Dreamacro/clash/hub/executor"
 	"github.com/Dreamacro/clash/log"
 
 	"github.com/go-chi/chi/v5"
@@ -44,7 +44,7 @@ func restart(w http.ResponseWriter, r *http.Request) {
 
 func runRestart(execPath string) {
 	var err error
-	listener.Cleanup(false)
+	executor.Shutdown()
 	if runtime.GOOS == "windows" {
 		cmd := exec.Command(execPath, os.Args[1:]...)
 		log.Infoln("restarting: %q %q", execPath, os.Args[1:])


### PR DESCRIPTION
当我使用 Api 来重启或更新 Meta 内核时，会出现 iptables 规则重复的情况。查看代码后发现是调用 `runRestart` 的时候没有清除 iptables。

我直接用 `executor.Shutdown()` 替换掉原来的 `listener.Cleanup(false)`，问题得到解决。

以下内容是因为在重启时没有清除规则导致的规则重复，这导致彻底退出 Meta 后也会残留部分规则，最终影响路由。
```
*nat
:PREROUTING ACCEPT [0:0]
:INPUT ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [0:0]
:clash_dns_output - [0:0]
-A PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p udp -m udp --dport 53 -j REDIRECT --to-ports 53
-A PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p tcp -m tcp --dport 53 -j REDIRECT --to-ports 53
-A PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p udp -m udp --dport 53 -j REDIRECT --to-ports 53
-A PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p tcp -m tcp --dport 53 -j REDIRECT --to-ports 53
-A PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p udp -m udp --dport 53 -j REDIRECT --to-ports 53
-A PREROUTING ! -s 172.17.0.0/16 ! -d 127.0.0.0/8 -p tcp -m tcp --dport 53 -j REDIRECT --to-ports 53
-A OUTPUT -p udp -m udp --dport 53 -j clash_dns_output
-A OUTPUT -p tcp -m tcp --dport 53 -j clash_dns_output
-A OUTPUT -p udp -m udp --dport 53 -j clash_dns_output
-A OUTPUT -p tcp -m tcp --dport 53 -j clash_dns_output
-A OUTPUT -p udp -m udp --dport 53 -j clash_dns_output
-A OUTPUT -p tcp -m tcp --dport 53 -j clash_dns_output
-A POSTROUTING -o eth0 -m addrtype ! --src-type LOCAL -j MASQUERADE
-A POSTROUTING -o eth0 -m addrtype ! --src-type LOCAL -j MASQUERADE
-A POSTROUTING -o eth0 -m addrtype ! --src-type LOCAL -j MASQUERADE
-A clash_dns_output -m mark --mark 0x86e -j RETURN
-A clash_dns_output -s 172.17.0.0/16 -j RETURN
-A clash_dns_output -p udp -j REDIRECT --to-ports 53
-A clash_dns_output -p tcp -j REDIRECT --to-ports 53
```