### PR TITLE
Fix restful api get tun conf.device, and clean Cleanup function

### DIFF
--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -491,7 +491,7 @@ func updateIPTables(cfg *config.Config) {
 }
 
 func Shutdown() {
-	listener.Cleanup(false)
+	listener.Cleanup()
 	tproxy.CleanupTProxyIPTables()
 	resolver.StoreFakePoolState()
 

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -134,7 +134,7 @@ func GetGeneral() *config.General {
 			RedirPort:         ports.RedirPort,
 			TProxyPort:        ports.TProxyPort,
 			MixedPort:         ports.MixedPort,
-			Tun:               listener.LastTunConf,
+			Tun:               listener.GetTunConf(),
 			TuicServer:        listener.GetTuicConf(),
 			ShadowSocksConfig: ports.ShadowSocksConfig,
 			VmessConfig:       ports.VmessConfig,

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -84,9 +84,7 @@ type Ports struct {
 
 func GetTunConf() LC.Tun {
 	if tunLister == nil {
-		return LC.Tun{
-			Enable: false,
-		}
+		return LastTunConf
 	}
 	return tunLister.Config()
 }

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -515,7 +515,6 @@ func ReCreateTun(tunConf LC.Tun, tcpIn chan<- C.ConnContext, udpIn chan<- C.Pack
 		if err != nil {
 			log.Errorln("Start TUN listening error: %s", err.Error())
 			tunConf.Enable = false
-			Cleanup(false)
 		}
 	}()
 
@@ -526,7 +525,7 @@ func ReCreateTun(tunConf LC.Tun, tcpIn chan<- C.ConnContext, udpIn chan<- C.Pack
 		return
 	}
 
-	Cleanup(true)
+	closeTunListener()
 
 	if !tunConf.Enable {
 		return
@@ -896,10 +895,13 @@ func hasTunConfigChange(tunConf *LC.Tun) bool {
 	return false
 }
 
-func Cleanup(wait bool) {
+func closeTunListener() {
 	if tunLister != nil {
 		tunLister.Close()
 		tunLister = nil
 	}
-	LastTunConf = LC.Tun{}
+}
+
+func Cleanup(wait bool) {
+	closeTunListener()
 }

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -902,6 +902,6 @@ func closeTunListener() {
 	}
 }
 
-func Cleanup(wait bool) {
+func Cleanup() {
 	closeTunListener()
 }


### PR DESCRIPTION
There is a mistake in my last commit 54fee7bd3a57ddd589a96f80b893b8524a9adf4f, which will cause once the `tun.device` is not explicitly configured, the RESTful api would fail to obtain the tun device name even if the tun device has already running.

This is because the default device name is specified directly by `sing_tun.server` instead of `LC.tun{}`. Thus it is necessary to get the current config directly when `tunLister` is available, so I reverted the changes to the executor.

-----

As for the second commit about Cleanup, I found that it is actually used in two places in `ReCreateTun`, but only one may take effect, and its modification to `LastTunConf` will always be reset.

Moreover, if other listeners have content,  such as ip link or ip rule, that needs to be cleaned up when the process is shutdown or restarted, those related methods should also be placed in `Cleanup`.

Therefore, I trimmed the relevant code and separated the logic of closing the tun device into another function.