### PR TITLE
feat: support clash premium's structured log stream

### DIFF
--- a/hub/route/server.go
+++ b/hub/route/server.go
@@ -293,11 +293,27 @@ type Log struct {
 	Type    string `json:"type"`
 	Payload string `json:"payload"`
 }
+type LogStructuredField struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+type LogStructured struct {
+	Time    string               `json:"time"`
+	Level   string               `json:"level"`
+	Message string               `json:"message"`
+	Fields  []LogStructuredField `json:"fields"`
+}
 
 func getLogs(w http.ResponseWriter, r *http.Request) {
 	levelText := r.URL.Query().Get("level")
 	if levelText == "" {
 		levelText = "info"
+	}
+
+	formatText := r.URL.Query().Get("format")
+	isStructured := false
+	if formatText == "structured" {
+		isStructured = true
 	}
 
 	level, ok := log.LogLevelMapping[levelText]
@@ -342,11 +358,26 @@ func getLogs(w http.ResponseWriter, r *http.Request) {
 		}
 		buf.Reset()
 
-		if err := json.NewEncoder(buf).Encode(Log{
-			Type:    logM.Type(),
-			Payload: logM.Payload,
-		}); err != nil {
-			break
+		if !isStructured {
+			if err := json.NewEncoder(buf).Encode(Log{
+				Type:    logM.Type(),
+				Payload: logM.Payload,
+			}); err != nil {
+				break
+			}
+		} else {
+			newLevel := logM.Type()
+			if newLevel == "warning" {
+				newLevel = "warn"
+			}
+			if err := json.NewEncoder(buf).Encode(LogStructured{
+				Time:    time.Now().Format(time.TimeOnly),
+				Level:   newLevel,
+				Message: logM.Payload,
+				Fields:  []LogStructuredField{},
+			}); err != nil {
+				break
+			}
 		}
 
 		var err error
@@ -364,5 +395,5 @@ func getLogs(w http.ResponseWriter, r *http.Request) {
 }
 
 func version(w http.ResponseWriter, r *http.Request) {
-	render.JSON(w, r, render.M{"meta": C.Meta, "version": C.Version})
+	render.JSON(w, r, render.M{"mete": C.Meta, "version": C.Version})
 }

--- a/hub/route/server.go
+++ b/hub/route/server.go
@@ -395,5 +395,5 @@ func getLogs(w http.ResponseWriter, r *http.Request) {
 }
 
 func version(w http.ResponseWriter, r *http.Request) {
-	render.JSON(w, r, render.M{"mete": C.Meta, "version": C.Version})
+	render.JSON(w, r, render.M{"meta": C.Meta, "version": C.Version})
 }


### PR DESCRIPTION
New version of Clash for Windows uses `ws://external-controller/logs?token=&level=info&format=structured` to get real time log. When Clash Premium Core reveices `format=structured`, it returns a different form of JSON log entry. Supporting this feature will allow better Clash for Windows integration