### PR TITLE
chore: reduce string split immediately after string concat

### DIFF
--- a/adapter/outbound/hysteria.go
+++ b/adapter/outbound/hysteria.go
@@ -46,7 +46,7 @@ type Hysteria struct {
 }
 
 func (h *Hysteria) DialContext(ctx context.Context, metadata *C.Metadata, opts ...dialer.Option) (C.Conn, error) {
-	tcpConn, err := h.client.DialTCP(metadata.RemoteAddress(), h.genHdc(ctx, opts...))
+	tcpConn, err := h.client.DialTCP(metadata.String(), metadata.DstPort, h.genHdc(ctx, opts...))
 	if err != nil {
 		return nil, err
 	}

--- a/adapter/outbound/hysteria2.go
+++ b/adapter/outbound/hysteria2.go
@@ -55,7 +55,7 @@ type Hysteria2Option struct {
 func (h *Hysteria2) DialContext(ctx context.Context, metadata *C.Metadata, opts ...dialer.Option) (_ C.Conn, err error) {
 	options := h.Base.DialOptions(opts...)
 	h.dialer.SetDialer(dialer.NewDialer(options...))
-	c, err := h.client.DialConn(ctx, M.ParseSocksaddr(metadata.RemoteAddress()))
+	c, err := h.client.DialConn(ctx, M.ParseSocksaddrHostPort(metadata.String(), metadata.DstPort))
 	if err != nil {
 		return nil, err
 	}

--- a/adapter/outbound/shadowsocks.go
+++ b/adapter/outbound/shadowsocks.go
@@ -123,9 +123,9 @@ func (ss *ShadowSocks) StreamConnContext(ctx context.Context, c net.Conn, metada
 		}
 	}
 	if useEarly {
-		return ss.method.DialEarlyConn(c, M.ParseSocksaddr(metadata.RemoteAddress())), nil
+		return ss.method.DialEarlyConn(c, M.ParseSocksaddrHostPort(metadata.String(), metadata.DstPort)), nil
 	} else {
-		return ss.method.DialConn(c, M.ParseSocksaddr(metadata.RemoteAddress()))
+		return ss.method.DialConn(c, M.ParseSocksaddrHostPort(metadata.String(), metadata.DstPort))
 	}
 }
 

--- a/adapter/outbound/singmux.go
+++ b/adapter/outbound/singmux.go
@@ -42,7 +42,7 @@ type ProxyBase interface {
 func (s *SingMux) DialContext(ctx context.Context, metadata *C.Metadata, opts ...dialer.Option) (_ C.Conn, err error) {
 	options := s.base.DialOptions(opts...)
 	s.dialer.SetDialer(dialer.NewDialer(options...))
-	c, err := s.client.DialContext(ctx, "tcp", M.ParseSocksaddr(metadata.RemoteAddress()))
+	c, err := s.client.DialContext(ctx, "tcp", M.ParseSocksaddrHostPort(metadata.String(), metadata.DstPort))
 	if err != nil {
 		return nil, err
 	}

--- a/adapter/outbound/vmess.go
+++ b/adapter/outbound/vmess.go
@@ -260,10 +260,10 @@ func (v *Vmess) streamConn(c net.Conn, metadata *C.Metadata) (conn net.Conn, err
 	} else {
 		if N.NeedHandshake(c) {
 			conn = v.client.DialEarlyConn(c,
-				M.ParseSocksaddr(metadata.RemoteAddress()))
+				M.ParseSocksaddrHostPort(metadata.String(), metadata.DstPort))
 		} else {
 			conn, err = v.client.DialConn(c,
-				M.ParseSocksaddr(metadata.RemoteAddress()))
+				M.ParseSocksaddrHostPort(metadata.String(), metadata.DstPort))
 		}
 	}
 	if err != nil {
@@ -284,7 +284,7 @@ func (v *Vmess) DialContext(ctx context.Context, metadata *C.Metadata, opts ...d
 			safeConnClose(c, err)
 		}(c)
 
-		c, err = v.client.DialConn(c, M.ParseSocksaddr(metadata.RemoteAddress()))
+		c, err = v.client.DialConn(c, M.ParseSocksaddrHostPort(metadata.String(), metadata.DstPort))
 		if err != nil {
 			return nil, err
 		}

--- a/transport/hysteria/core/client.go
+++ b/transport/hysteria/core/client.go
@@ -194,11 +194,7 @@ func (c *Client) openStreamWithReconnect(dialer utils.PacketDialer) (quic.Connec
 	return c.quicSession, &wrappedQUICStream{stream}, err
 }
 
-func (c *Client) DialTCP(addr string, dialer utils.PacketDialer) (net.Conn, error) {
-	host, port, err := utils.SplitHostPort(addr)
-	if err != nil {
-		return nil, err
-	}
+func (c *Client) DialTCP(host string, port uint16, dialer utils.PacketDialer) (net.Conn, error) {
 	session, stream, err := c.openStreamWithReconnect(dialer)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`metadata.RemoteAddress()` is implemented with `net.JoinHostPort`:

https://github.com/MetaCubeX/Clash.Meta/blob/fdd327d58da49b0bf21b0908bc7e3d475eae63a3/constant/metadata.go#L154-L157

However, most use cases of `RemoteAddress()` is passing it to `M.ParseSocksaddr`, which is implemented with `net.SplitHostPort`

https://github.com/MetaCubeX/sing/blob/f9766a597f7dbd6919a9b60c1eb1e41221e3ab1d/common/metadata/addr.go#L186-L195

Those redundant string concatenations can be ruled out by making use of `M.ParseSocksaddrHostPort`.
