### PR TITLE
fix: add a missing config member in android patch

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -319,6 +319,8 @@ type RawConfig struct {
 	SubRules      map[string][]string       `yaml:"sub-rules"`
 	RawTLS        TLS                       `yaml:"tls"`
 	Listeners     []map[string]any          `yaml:"listeners"`
+
+	ClashForAndroid RawClashForAndroid      `yaml:"clash-for-android"`
 }
 
 type GeoXUrl struct {


### PR DESCRIPTION
To pass compile of Clash Meta for Android
![image](https://github.com/MetaCubeX/Clash.Meta/assets/144257728/917dd477-3c9c-4a1c-8bb2-a3ba7e3a90ff)

This member exists in Kr238's patched clash core for android (https://github.com/Kr328/clash/blob/68b653837decdb889045ed5525013b73509ad94d/config/config.go#L157)
But missing in clash meta core

Related issue: #799 