### PR TITLE
自动关闭尚未确认且长时间不活跃的issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,6 +42,11 @@ I have read the [documentation](https://wiki.metacubex.one/) and was unable to s
 This is an issue of the Clash core *per se*, not to the derivatives of Clash, like OpenClash or KoolClash.
 "
           required: true
+        - label: "
+我将保持此issue的活跃状态，直到开发者确认此问题的存在并列入计划
+I will keep this issue active, until the developers confirm the existance of bug and include it in the plan.
+"
+          required: true
   - type: input
     attributes:
       label: Clash version

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -22,6 +22,11 @@ I have searched on the [issue tracker](……/) for a related feature request.
 I have read the [documentation](https://wiki.metacubex.one/) and was unable to solve the issue.
 "
           required: true
+        - label: "
+我将保持此issue的活跃状态，直到开发者接受此功能并列入计划
+I will keep this issue active, until the developers accept this feature and include it in the plan.
+"
+          required: true
   - type: textarea
     attributes:
       label: Description

--- a/.github/workflows/close-unactive-issues.yml
+++ b/.github/workflows/close-unactive-issues.yml
@@ -16,7 +16,7 @@ jobs:
           days-before-issue-close: 14
           stale-issue-label: "stale"
           exempt-issue-labels: "pinned, security, priority: high, priority: normal, priority: low"
-          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity. Remove stale label or comment or this will be closed in 14 days"
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity. Remove stale label or comment, or this issue will be closed in 14 days"
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
           days-before-pr-stale: -1        # Do not stale PR
           days-before-pr-close: -1        # Do not stale PR

--- a/.github/workflows/close-unactive-issues.yml
+++ b/.github/workflows/close-unactive-issues.yml
@@ -1,0 +1,23 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 3 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          exempt-issue-labels: "pinned, security, priority: high, priority: normal, priority: low"
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity. Remove stale label or comment or this will be closed in 14 days"
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1        # Do not stale PR
+          days-before-pr-close: -1        # Do not stale PR
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
内核仓库历史issue堆积过多，一个个手动筛选排查不便，且过时较久的issue时效性不佳，如果没有明确列入计划建议自动关闭，以免继续大量堆积。

此actions设定每天凌晨三点执行检查，对所有未有任何活跃超过60天的Issue打上stale标签并回复警告，如果再过14天仍然没有任何活跃即自动关闭。
排除打了下面这些标签的issue：`pinned`, `security`, `priority: high`, `priority: normal`, `priority: low`。如果确定接受此issue，任意开发者打上这些label之一即可永久避开检查。

security用于标记安全问题，`priority: xxx`用于将目标issue列入计划，按不同优先级分级