### PR TITLE
fix: remote logic rules cannot be parsed

### DIFF
--- a/rules/provider/classical_strategy.go
+++ b/rules/provider/classical_strategy.go
@@ -76,7 +76,11 @@ func ruleParse(ruleRaw string) (string, string, []string) {
 	} else if len(item) == 2 {
 		return item[0], item[1], nil
 	} else if len(item) > 2 {
-		return item[0], item[1], item[2:]
+		if item[0] == "NOT" || item[0] == "OR" || item[0] == "AND" || item[0] == "SUB-RULE" {
+			return item[0], strings.Join(item[1:len(item)], ","), nil
+		} else {
+			return item[0], item[1], item[2:]
+		}
 	}
 
 	return "", "", nil


### PR DESCRIPTION
Logic rules like AND,OR,SUB-RULE, etc have a different rule structure than traditional rules. The parser used in ./config/config.go was updated accordingly when adding these rule types but the parser used  in ./rules/provider/parse.go was not, making logic rules in remote providers not working as expected.